### PR TITLE
WIP:feat/direct-mqtt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
     - LOWERCASE_REPO_SLUG="${TRAVIS_REPO_SLUG,,}"
     - DOCKER_LOCAL="${LOWERCASE_REPO_SLUG}:${TRAVIS_COMMIT}"
     - DOCKER_DEV_TAG="${LOWERCASE_REPO_SLUG}:develop"
+    - DOCKER_DIRECT_MQTT_TAG="${LOWERCASE_REPO_SLUG}:direct-mqtt"
     - BUILD_HASH=$(echo "${TRAVIS_COMMIT}" | cut -c1-7)
 
 before_install:
@@ -42,6 +43,10 @@ deploy:
     script: sh ./.travis/docker_login_tag_push "${DOCKER_LOCAL}" "${DOCKER_DEV_TAG}"
     on:
       branch: develop
+  - provider: script
+    script: sh ./.travis/docker_login_tag_push "${DOCKER_LOCAL}" "${DOCKER_DIRECT_MQTT_TAG}"
+    on:
+      branch: feat/direct-mqtt
   - provider: script
     script: sh ./.travis/docker_login_tag_semver_push "${DOCKER_LOCAL}" "${LOWERCASE_REPO_SLUG}" "${TRAVIS_TAG}" "${BUILD_HASH}"
     on:

--- a/pom.xml
+++ b/pom.xml
@@ -9,10 +9,15 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <common.version>1.0.6</common.version>
+        <common.version>1.1.0</common.version>
+        <paho.version>1.2.0</paho.version>
     </properties>
 
     <repositories>
+        <repository>
+            <id>Eclipse Paho Repo</id>
+            <url>https://repo.eclipse.org/content/repositories/paho-releases/</url>
+        </repository>
         <repository>
           <id>bintray</id>
           <name>bintray</name>
@@ -25,6 +30,12 @@
             <groupId>fi.hsl</groupId>
             <artifactId>transitdata-common</artifactId>
             <version>${common.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.paho</groupId>
+            <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
+            <version>${paho.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/fi/hsl/transitlog/hfp/Credentials.java
+++ b/src/main/java/fi/hsl/transitlog/hfp/Credentials.java
@@ -1,0 +1,48 @@
+package fi.hsl.transitlog.hfp;
+
+import com.typesafe.config.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.Optional;
+import java.util.Scanner;
+
+public class Credentials {
+    private static final Logger log = LoggerFactory.getLogger(Credentials.class);
+
+    public String username;
+    public String password;
+
+    public Credentials(String user, String pw) {
+        username = user;
+        password = pw;
+    }
+
+    public static Optional<Credentials> readMqttCredentials(Config config) throws Exception {
+        try {
+            if (!config.getBoolean("mqtt-broker.credentials.required")) {
+                log.info("Login credentials not required");
+                return Optional.empty();
+            }
+            else {
+                //Default path is what works with Docker out-of-the-box. Override with a local file if needed
+                final String usernamePath = config.getString("mqtt-broker.credentials.usernameFilepath");
+                log.debug("Reading username from " + usernamePath);
+                String username = new Scanner(new File(usernamePath)).useDelimiter("\\Z").next();
+
+                final String passwordPath = config.getString("mqtt-broker.credentials.passwordFilepath");
+                log.debug("Reading password from " + passwordPath);
+                String password = new Scanner(new File(passwordPath)).useDelimiter("\\Z").next();
+
+                log.info("Login credentials read from files successfully");
+                return Optional.of(new Credentials(username, password));
+            }
+        } catch (Exception e) {
+            log.error("Failed to read login credentials from secret files", e);
+            throw e;
+        }
+    }
+
+
+}

--- a/src/main/java/fi/hsl/transitlog/hfp/IMqttMessageHandler.java
+++ b/src/main/java/fi/hsl/transitlog/hfp/IMqttMessageHandler.java
@@ -1,0 +1,12 @@
+package fi.hsl.transitlog.hfp;
+
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+
+/**
+ * Paho has multiple interfaces but none of them seem to support our use case of receiving events for both
+ * message-arrived and client-disconnected event. So we'll wrap our own interface.
+ */
+public interface IMqttMessageHandler {
+    void handleMessage(String topic, MqttMessage message) throws Exception;
+    void connectionLost(Throwable cause);
+}

--- a/src/main/java/fi/hsl/transitlog/hfp/Main.java
+++ b/src/main/java/fi/hsl/transitlog/hfp/Main.java
@@ -3,11 +3,13 @@ package fi.hsl.transitlog.hfp;
 import com.typesafe.config.Config;
 import fi.hsl.common.config.ConfigParser;
 import fi.hsl.common.config.ConfigUtils;
+import fi.hsl.common.health.HealthServer;
 import fi.hsl.common.pulsar.PulsarApplication;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
+import java.util.function.BooleanSupplier;
 
 public class Main {
     private static final Logger log = LoggerFactory.getLogger(Main.class);
@@ -17,16 +19,40 @@ public class Main {
 
         Config config = ConfigParser.createConfig();
 
-        log.info("Configuration read, launching the main loop");
         MessageProcessor processor = null;
         QueueWriter writer = null;
-        try (PulsarApplication app = PulsarApplication.newInstance(config)) {
+        MqttConnector connector = null;
+        try {
             final String connectionString = ConfigUtils.getConnectionStringFromFileOrThrow(Optional.of("/run/secrets/db_conn_string"));
             writer = QueueWriter.newInstance(config, connectionString);
-            processor = MessageProcessor.newInstance(app, writer);
-            log.info("Starting to process messages");
 
-            app.launchWithHandler(processor);
+            Optional<Credentials> credentials = Credentials.readMqttCredentials(config);
+
+            log.info("Configurations read, connecting.");
+
+            connector = new MqttConnector(config, credentials);
+            final MqttConnector connectorRef = connector;
+
+            // Add custom health check for MQTT connection
+            final BooleanSupplier connectorHealthCheck = () -> {
+                if (connectorRef != null) {
+                    return connectorRef.isConnected();
+                }
+                return false;
+            };
+            PulsarApplication app = PulsarApplication.newInstance(config);
+            HealthServer healthServer = app.getContext().getHealthServer();
+            if (healthServer != null) {
+                healthServer.addCheck(connectorHealthCheck);
+            }
+
+            processor = MessageProcessor.newInstance(config, connector, writer);
+            //Let's subscribe to connector before connecting so we'll get all the events.
+            connector.subscribe(processor);
+
+            connector.connect();
+
+            log.info("Connections established, let's process some messages");
         }
         catch (Exception e) {
             log.error("Exception at main", e);
@@ -35,6 +61,9 @@ public class Main {
             }
             if (writer != null) {
                 writer.close();
+            }
+            if (connector != null) {
+                connector.close();
             }
         }
     }

--- a/src/main/java/fi/hsl/transitlog/hfp/MessageProcessor.java
+++ b/src/main/java/fi/hsl/transitlog/hfp/MessageProcessor.java
@@ -1,15 +1,11 @@
 package fi.hsl.transitlog.hfp;
 
+import com.typesafe.config.Config;
+import fi.hsl.common.hfp.HfpJson;
+import fi.hsl.common.hfp.HfpParser;
 import fi.hsl.common.hfp.proto.Hfp;
-import fi.hsl.common.pulsar.IMessageHandler;
 
-import fi.hsl.common.pulsar.PulsarApplication;
-import fi.hsl.common.pulsar.PulsarApplicationContext;
-import fi.hsl.common.transitdata.TransitdataProperties;
-import fi.hsl.common.transitdata.TransitdataSchema;
-import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.MessageId;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,29 +14,32 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-public class MessageProcessor implements IMessageHandler {
+public class MessageProcessor implements IMqttMessageHandler {
 
     private static final Logger log = LoggerFactory.getLogger(MessageProcessor.class);
 
     final ArrayList<Hfp.Data> queue;
     final int QUEUE_MAX_SIZE = 100000;
     final QueueWriter writer;
-    private final Consumer<byte[]> consumer;
-    private final PulsarApplication application;
 
     ScheduledExecutorService scheduler;
 
-    private MessageProcessor(PulsarApplication app, QueueWriter w) {
+    final MqttConnector connector;
+
+    private boolean shutdownInProgress = false;
+
+    private final HfpParser parser = HfpParser.newInstance();
+
+    private MessageProcessor(MqttConnector connector, QueueWriter w) {
         queue = new ArrayList<>(QUEUE_MAX_SIZE);
         writer = w;
-        consumer = app.getContext().getConsumer();
-        application = app;
+        this.connector = connector;
     }
 
-    public static MessageProcessor newInstance(PulsarApplication app, QueueWriter writer) throws Exception {
-        final long intervalInMs = app.getContext().getConfig().getDuration("application.dumpInterval", TimeUnit.MILLISECONDS);
+    public static MessageProcessor newInstance(Config config, MqttConnector connector, QueueWriter writer) throws Exception {
+        final long intervalInMs = config.getDuration("application.dumpInterval", TimeUnit.MILLISECONDS);
 
-        MessageProcessor processor = new MessageProcessor(app, writer);
+        MessageProcessor processor = new MessageProcessor(connector, writer);
         log.info("Let's start the dump-executor");
         processor.startDumpExecutor(intervalInMs);
         return processor;
@@ -71,7 +70,7 @@ public class MessageProcessor implements IMessageHandler {
         }
 
         if (copy.isEmpty()) {
-            log.info("Queue empty, no messages to write to database");
+            log.warn("Queue empty, no messages to write to database");
         }
         else {
             log.info("Writing {} messages to database", copy.size());
@@ -80,42 +79,91 @@ public class MessageProcessor implements IMessageHandler {
     }
 
     @Override
-    public void handleMessage(Message message) throws Exception {
+    public void handleMessage(String topic, MqttMessage message) throws Exception {
         if (queue.size() > QUEUE_MAX_SIZE) {
             //TODO think what to do if queue is full!
             log.error("Queue full: " + QUEUE_MAX_SIZE);
             return;
         }
 
-        if (TransitdataSchema.hasProtobufSchema(message, TransitdataProperties.ProtobufSchema.HfpData)) {
-            Hfp.Data data = Hfp.Data.parseFrom(message.getData());
-            synchronized (queue) {
-                queue.add(data);
+        try {
+            // This method is invoked synchronously by the MQTT client (via our connector), so all events arrive in the same thread
+            // https://www.eclipse.org/paho/files/javadoc/org/eclipse/paho/client/mqttv3/MqttCallback.html
+
+            // Optimally we would like to send the event to Pulsar synchronously and validate that it was a success,
+            // and only after that acknowledge the message to mqtt by returning gracefully from this function.
+            // This works if the rate of incoming messages is low enough to complete the Pulsar transaction.
+            // This would allow us to deliver messages once and only once, in insertion order
+
+            // If we want to improve our performance and lose guarantees of once-and-only-once,
+            // we can optimize the pipeline by sending messages asynchronously to Pulsar.
+            // This means that data will be lost on insertion errors.
+            // Using a single producer however should guarantee insertion-order guarantee between two consecutive messages.
+
+            // Current implementation uses the latter approach
+
+            if (!connector.isConnected()) {
+                log.error("MQTT client is no longer connected. Exiting application");
+                throw new Exception("MQTT client is no longer connected");
             }
+
+            long now = System.currentTimeMillis();
+
+            byte[] payload = message.getPayload();
+
+            if (payload != null) {
+                Hfp.Data data = parseData(topic, payload, now);
+                synchronized (queue) {
+                    queue.add(data);
+                }
+            }
+            else {
+                log.warn("Cannot process MQTT message because content is null");
+            }
+
         }
-        else {
-            log.warn("Invalid protobuf schema, expecting HfpData");
+        catch (Exception e) {
+            log.error("Error while handling the message", e);
+            // Let's close everything and restart.
+            // Closing the MQTT connection should enable us to receive the same message again.
+            close(true);
+            throw e;
         }
-        ack(message.getMessageId());
     }
 
-    private void ack(MessageId received) {
-        consumer.acknowledgeAsync(received)
-                .exceptionally(throwable -> {
-                    log.error("Failed to ack Pulsar message", throwable);
-                    return null;
-                })
-                .thenRun(() -> {});
+    Hfp.Data parseData(String rawTopic, byte[] rawPayload, long timestamp) throws Exception {
+        final HfpJson jsonPayload = parser.parseJson(rawPayload);
+        Hfp.Payload payload = HfpParser.parsePayload(jsonPayload);
+        Hfp.Topic topic = HfpParser.parseTopic(rawTopic, timestamp);
+
+        Hfp.Data.Builder builder = Hfp.Data.newBuilder();
+        builder.setSchemaVersion(builder.getSchemaVersion())
+                .setPayload(payload)
+                .setTopic(topic);
+        return builder.build();
     }
 
-    public void close(boolean closePulsar) {
+    @Override
+    public void connectionLost(Throwable cause) {
+        log.info("Mqtt connection lost");
+        close(false);
+    }
+
+    public void close(boolean closeMqtt) {
+        if (shutdownInProgress) {
+            return;
+        }
+        shutdownInProgress = true;
+
         log.warn("Closing MessageProcessor resources");
         scheduler.shutdown();
         log.info("Scheduler shutdown finished");
-        if (closePulsar && application != null) {
-            log.info("Closing also Pulsar application");
-            application.close();
+
+        log.warn("Closing MessageProcessor resources");
+        //Let's first close the MQTT to stop the event stream.
+        if (closeMqtt) {
+            connector.close();
+            log.info("MQTT connection closed");
         }
     }
-
 }

--- a/src/main/java/fi/hsl/transitlog/hfp/MqttConnector.java
+++ b/src/main/java/fi/hsl/transitlog/hfp/MqttConnector.java
@@ -1,0 +1,139 @@
+package fi.hsl.transitlog.hfp;
+
+import com.typesafe.config.Config;
+import org.eclipse.paho.client.mqttv3.*;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedList;
+import java.util.Optional;
+import java.util.UUID;
+
+public class MqttConnector implements MqttCallback {
+    private static final Logger log = LoggerFactory.getLogger(MqttConnector.class);
+
+    private final String mqttTopic;
+    private final int qos;
+    private final String clientId;
+    private final String broker;
+
+    private final MqttConnectOptions connectOptions;
+    private final LinkedList<IMqttMessageHandler> handlers = new LinkedList<>();
+
+    private MqttClient mqttClient;
+
+    public MqttConnector(Config config, Optional<Credentials> maybeCredentials) {
+        mqttTopic = config.getString("mqtt-broker.topic");
+        qos = config.getInt("mqtt-broker.qos");
+        clientId = createClientId(config);
+        broker = config.getString("mqtt-broker.host");
+
+        final int maxInFlight = config.getInt("mqtt-broker.maxInflight");
+        final boolean cleanSession = config.getBoolean("mqtt-broker.cleanSession");
+
+        connectOptions = new MqttConnectOptions();
+        connectOptions.setCleanSession(cleanSession);
+        connectOptions.setMaxInflight(maxInFlight);
+        connectOptions.setAutomaticReconnect(false); //Let's abort on connection errors
+
+        maybeCredentials.ifPresent(credentials -> {
+            connectOptions.setUserName(credentials.username);
+            connectOptions.setPassword(credentials.password.toCharArray());
+        });
+        connectOptions.setConnectionTimeout(10);
+    }
+
+    String createClientId(Config config) {
+        String clientId = config.getString("mqtt-broker.clientId");
+        if (config.getBoolean("mqtt-broker.addRandomnessToClientId")) {
+            clientId += "-" + UUID.randomUUID().toString().substring(0, 8);
+        }
+        return clientId;
+    }
+
+    public void subscribe(IMqttMessageHandler handler) {
+        //let's not subscribe to the actual client. we have our own observables here
+        //since we want to provide the disconnected-event via the same interface.
+        log.info("Adding subscription");
+        handlers.add(handler);
+    }
+
+    public void connect() throws Exception {
+        MqttClient client = null;
+        try {
+            //Let's use memory persistance to optimize throughput.
+            MemoryPersistence memoryPersistence = new MemoryPersistence();
+
+            client = new MqttClient(broker, clientId, memoryPersistence);
+            client.setCallback(this); //Let's add the callback before connecting so we won't lose any messages
+
+            log.info(String.format("Connecting to mqtt broker %s", broker));
+            IMqttToken token = client.connectWithResult(connectOptions);
+
+            log.info("Connection to MQTT completed? {}", token.isComplete());
+            if (token.getException() != null) {
+                throw token.getException();
+            }
+        }
+        catch (Exception e) {
+            log.error("Error connecting to MQTT broker", e);
+            if (client != null) {
+                //Paho doesn't close the connection threads unless we force-close it.
+                client.close(true);
+            }
+            throw e;
+        }
+
+        try {
+            log.info("Subscribing to topic {} with QoS {}", mqttTopic, qos);
+            mqttClient = client;
+            mqttClient.subscribe(mqttTopic, qos);
+        }
+        catch (Exception e) {
+            log.error("Error subscribing to MQTT broker", e);
+            close();
+            throw e;
+        }
+    }
+
+    @Override
+    public void connectionLost(Throwable cause) {
+        log.error("Connection to mqtt broker lost, notifying clients", cause);
+        for (IMqttMessageHandler handler: handlers) {
+            handler.connectionLost(cause);
+        }
+        close();
+    }
+
+    @Override
+    public void messageArrived(String topic, MqttMessage message) throws Exception {
+        for (IMqttMessageHandler handler: handlers) {
+            handler.handleMessage(topic, message);
+        }
+    }
+
+    @Override
+    public void deliveryComplete(IMqttDeliveryToken token) {}
+
+    public void close() {
+        if (mqttClient == null) {
+            log.warn("Cannot close mqtt connection since it's null");
+            return;
+        }
+        try {
+            log.info("Closing MqttConnector resources");
+            //Paho doesn't close the connection threads unless we first disconnect and then force-close it.
+            mqttClient.disconnectForcibly(5000L);
+            mqttClient.close(true);
+            mqttClient = null;
+        }
+        catch (Exception e) {
+            log.error("Failed to close MQTT client connection", e);
+        }
+    }
+
+    public boolean isConnected() {
+        return mqttClient.isConnected();
+    }
+}

--- a/src/main/resources/environment.conf
+++ b/src/main/resources/environment.conf
@@ -2,17 +2,41 @@ include "common.conf"
 
 pulsar {
   consumer {
-    topic="hfp-data"
-    topic=${?PULSAR_CONSUMER_TOPIC}
-    subscription="transitlog-hfp-sink-sub"
-    subscription=${?PULSAR_CONSUMER_SUBSCRIPTION}
+    enabled=false
   }
   producer {
-    enabled = false
+    enabled=false
   }
 }
 
 application {
-  dumpInterval = 1 seconds
-  dumpInterval = ${?DUMP_INTERVAL}
+  dumpInterval=1 seconds
+  dumpInterval=${?DUMP_INTERVAL}
+}
+
+mqtt-broker {
+  host="ssl://mqtt.hsl.fi:8883"
+  host=${?MQTT_BROKER_HOST}
+  qos=1
+  qos=${?MQTT_QOS}
+  topic="/hfp/v2/journey/ongoing/vp/#"
+  topic=${?MQTT_TOPIC}
+  maxInflight=10000
+  maxInflight=${?MQTT_MAX_INFLIGHT}
+  cleanSession=false
+  cleanSession=${?MQTT_CLEAN_SESSION}
+  # MQTT requires unique client-id's so make sure to change this in prod.
+  clientId="mqtt-pulsar-gateway"
+  clientId=${?MQTT_CLIENT_ID}
+  addRandomnessToClientId=true
+  addRandomnessToClientId=${?MQTT_ADD_RANDOM_TO_CLIENT_ID}
+  credentials {
+    #If required, read username and password from Docker-secrets from this file path
+    required=false
+    required=${?MQTT_CREDENTIALS_REQUIRED}
+    usernameFilepath="/run/secrets/mqtt_broker_username"
+    usernameFilepath=${?FILEPATH_USERNAME_SECRET}
+    passwordFilepath="/run/secrets/mqtt_broker_password"
+    passwordFilepath=${?FILEPATH_PASSWORD_SECRET}
+  }
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -12,7 +12,7 @@
             </layout>
         </encoder>
     </appender>
-    <logger name="fi.hsl" level="debug" additivity="false">
+    <logger name="fi.hsl" level="info" additivity="false">
         <appender-ref ref="stdout" />
     </logger>
     <root level="warn">


### PR DESCRIPTION
Temporary modification to app so it reads HFP messages directly from MQTT broker instead of intended Pulsar pipeline

 - This is temporary solution until performance problem (too low message rate) with Pulsar is resolved
 - Add MQTT client for reading MQTT messages and MQTT related configs
 - Add HFP parsing
 - Use transitdata-common version which supports HFP v2
 - Add custom health check to monitor MQTT connection
 - Create separate docker image to Docker Hub with tag direct-mqtt
 - Change log level from debug to info
 - Remove Pulsar consumer